### PR TITLE
add a focus state

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -37,18 +37,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     paper-fab.blue {
       --paper-fab-background: var(--paper-light-blue-500);
+      --paper-fab-keyboard-focus-background: var(--paper-light-blue-900);
     }
 
     paper-fab.red {
       --paper-fab-background: var(--paper-red-500);
+      --paper-fab-keyboard-focus-background: var(--paper-red-900);
     }
 
     paper-fab.green {
       --paper-fab-background: var(--paper-green-500);
+      --paper-fab-keyboard-focus-background: var(--paper-green-900);
     }
 
     paper-fab.orange {
       --paper-fab-background: var(--paper-orange-500);
+      --paper-fab-keyboard-focus-background: var(--paper-orange-900);
     }
 
   </style>

--- a/paper-fab.html
+++ b/paper-fab.html
@@ -42,7 +42,8 @@ The following custom properties and mixins are available for styling:
 
 Custom property | Description | Default
 ----------------|-------------|----------
-`--paper-fab-background` | The background color of the button | `--paper-indigo-500`
+`--paper-fab-background` | The background color of the button | `--accent-color`
+`--paper-fab-keyboard-focus-background` | The background color of the button when focused | `--paper-pink-900`
 `--paper-fab-disabled-background` | The background color of the button when it's disabled | `--paper-grey-300`
 `--paper-fab-disabled-text` | The text color of the button when it's disabled | `--paper-grey-500`
 `--paper-fab` | Mixin applied to the button | `{}`
@@ -71,7 +72,7 @@ Custom property | Description | Default
       min-width: 0;
       width: 56px;
       height: 56px;
-      background: var(--paper-fab-background, --paper-indigo-500);
+      background: var(--paper-fab-background, --accent-color);
       color: var(--text-primary-color);
       border-radius: 50%;
       padding: 16px;
@@ -97,11 +98,18 @@ Custom property | Description | Default
 
     paper-material {
       border-radius: inherit;
+      @apply(--layout-fit);
+      @apply(--layout-vertical);
+      @apply(--layout-center-center);
+    }
+
+    .keyboard-focus {
+      background: var(--paper-fab-keyboard-focus-background, --paper-pink-900);
     }
   </style>
   <template>
     <paper-ripple></paper-ripple>
-    <paper-material class="content fit flex layout vertical center-center" elevation="[[elevation]]" animated>
+    <paper-material class$="[[_computeContentClass(receivedFocusFromKeyboard)]]" elevation="[[_elevation]]" animated>
       <iron-icon id="icon" src="[[src]]" icon="[[icon]]"></iron-icon>
     </paper-material>
   </template>
@@ -153,6 +161,14 @@ Custom property | Description | Default
         type: Boolean,
         value: false
       }
+    },
+
+    _computeContentClass: function(receivedFocusFromKeyboard) {
+      var className = 'content';
+      if (receivedFocusFromKeyboard) {
+        className += ' keyboard-focus';
+      }
+      return className;
     }
 
   });


### PR DESCRIPTION
Focus states, now at a button near you! 👌

Fixes https://github.com/PolymerElements/paper-fab/issues/4 (adds elevation and darkens the background colour), and https://github.com/PolymerElements/paper-fab/issues/12 (made it be pink by default again). This focused colour can be styled with `--paper-fab-keyboard-focus-background` which gets bonus points for verbosity (suggestions welcome).

![screen shot 2015-06-03 at 4 44 50 pm](https://cloud.githubusercontent.com/assets/1369170/7974375/d0837ddc-0a15-11e5-99d0-cff5a07b8fe0.png)


