### PR TITLE
mini needs to be a reflected property

### DIFF
--- a/paper-fab.html
+++ b/paper-fab.html
@@ -159,7 +159,8 @@ Custom property | Description | Default
        */
       mini: {
         type: Boolean,
-        value: false
+        value: false,
+        reflectToAttribute: true
       }
     },
 


### PR DESCRIPTION
Fixes #18.
The css style is `:host([mini])` and it doesn't get applied when imperatively changing the `mini` property.

@cdata PTAL 💰