### PR TITLE
use new paper-material styles

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,7 @@
     "iron-icon": "PolymerElements/iron-icon#^1.0.0",
     "iron-icons": "PolymerElements/iron-icons#^1.0.0",
     "paper-behaviors": "PolymerElements/paper-behaviors#^1.0.0",
-    "paper-material": "PolymerElements/paper-material#^1.0.0",
+    "paper-material": "PolymerElements/paper-material#^1.0.5",
     "paper-ripple": "PolymerElements/paper-ripple#^1.0.0",
     "paper-styles": "PolymerElements/paper-styles#^1.0.0",
     "polymer": "Polymer/polymer#^1.0.0"

--- a/paper-fab.html
+++ b/paper-fab.html
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
 <link rel="import" href="../iron-icon/iron-icon.html">
 <link rel="import" href="../paper-behaviors/paper-button-behavior.html">
-<link rel="import" href="../paper-material/paper-material.html">
+<link rel="import" href="../paper-material/paper-material-shared-styles.html">
 <link rel="import" href="../paper-ripple/paper-ripple.html">
 <link rel="import" href="../paper-styles/color.html">
 <link rel="import" href="../paper-styles/default-theme.html">
@@ -58,7 +58,7 @@ Custom property | Description | Default
 
 <dom-module id="paper-fab">
   <template strip-whitespace>
-    <style include="paper-material">
+    <style include="paper-material-shared-styles">
       :host {
         display: inline-block;
         position: relative;


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/paper-fab/issues/34

Since https://github.com/PolymerElements/paper-fab/commit/3847918e87728c609bf820bdca4792c5f8013805, `paper-fab` is applying all the styles `paper-material` used to have, including a pretty specific `:host[animated]`, which now stomps over any other `transition` styles you might apply to a `paper-fab`. Since `paper-fab` doesn't declare or use the `animated` property, it shouldn't be using its style either.

Tests will fail until https://github.com/PolymerElements/paper-material/pull/26 lands, because I'm explicitly targetting that release in `bower`