### PR TITLE
Patch to add label (Issue #56)

### DIFF
--- a/paper-fab.html
+++ b/paper-fab.html
@@ -109,8 +109,8 @@ Custom property | Description | Default
       }
     </style>
 
-    <iron-icon id="icon" hidden$="{{!_computeIsIconFab(icon)}}" src="[[src]]" icon="[[icon]]"></iron-icon>
-    <span id="fab-text" hidden$="{{_computeIsIconFab(icon)}}">{{label}}</span>
+    <iron-icon id="icon" hidden$="{{!isIconFab}}" src="[[src]]" icon="[[icon]]"></iron-icon>
+    <span id="fab-text" hidden$="{{isIconFab}}">{{label}}</span>
   </template>
 
   <script>
@@ -157,6 +157,14 @@ Custom property | Description | Default
         label: {
           type: String,
           observer: '_labelChanged'
+        },
+        
+        /**
+         * This is true if an icon has been set.
+         */
+        isIconFab: {
+          type: Boolean,
+          computed: '_computeIsIconFab(icon, src)'
         }
       },
       
@@ -164,8 +172,8 @@ Custom property | Description | Default
         this.setAttribute('aria-label', this.label);
       },
       
-      _computeIsIconFab: function(icon) {
-        return icon.length > 0;
+      _computeIsIconFab: function(icon, src) {
+        return (icon.length > 0) || (src.length > 0);
       }
     });
   </script>

--- a/paper-fab.html
+++ b/paper-fab.html
@@ -109,7 +109,8 @@ Custom property | Description | Default
       }
     </style>
 
-    <iron-icon id="icon" src="[[src]]" icon="[[icon]]"></iron-icon>
+    <iron-icon id="icon" hidden$="{{!_computeIsIconFab(icon)}}" src="[[src]]" icon="[[icon]]"></iron-icon>
+    <span id="fab-text" hidden$="{{_computeIsIconFab(icon)}}">{{label}}</span>
   </template>
 
   <script>
@@ -147,7 +148,24 @@ Custom property | Description | Default
           type: Boolean,
           value: false,
           reflectToAttribute: true
+        },
+        
+        /**
+         * The label displayed in the badge. The label is centered, and ideally
+         * should have very few characters.
+         */
+        label: {
+          type: String,
+          observer: '_labelChanged'
         }
+      },
+      
+      _labelChanged: function() {
+        this.setAttribute('aria-label', this.label);
+      },
+      
+      _computeIsIconFab: function(icon) {
+        return icon.length > 0;
       }
     });
   </script>

--- a/paper-fab.html
+++ b/paper-fab.html
@@ -116,8 +116,8 @@ Custom property | Description | Default
       }
     </style>
 
-    <iron-icon id="icon" hidden$="{{!isIconFab}}" src="[[src]]" icon="[[icon]]"></iron-icon>
-    <span hidden$="{{isIconFab}}">{{label}}</span>
+    <iron-icon id="icon" hidden$="{{!_computeIsIconFab(icon, src)}}" src="[[src]]" icon="[[icon]]"></iron-icon>
+    <span hidden$="{{_computeIsIconFab(icon, src)}}">{{label}}</span>
   </template>
 
   <script>
@@ -164,14 +164,6 @@ Custom property | Description | Default
         label: {
           type: String,
           observer: '_labelChanged'
-        },
-        
-        /**
-         * This is true if an icon has been set.
-         */
-        isIconFab: {
-          type: Boolean,
-          computed: '_computeIsIconFab(icon, src)'
         }
       },
       

--- a/paper-fab.html
+++ b/paper-fab.html
@@ -103,6 +103,13 @@ Custom property | Description | Default
       iron-icon {
         @apply(--paper-fab-iron-icon);
       }
+      
+      span {
+        width: 100%;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
 
       :host(.keyboard-focus) {
         background: var(--paper-fab-keyboard-focus-background, --paper-pink-900);
@@ -110,7 +117,7 @@ Custom property | Description | Default
     </style>
 
     <iron-icon id="icon" hidden$="{{!isIconFab}}" src="[[src]]" icon="[[icon]]"></iron-icon>
-    <span id="fab-text" hidden$="{{isIconFab}}">{{label}}</span>
+    <span hidden$="{{isIconFab}}">{{label}}</span>
   </template>
 
   <script>

--- a/test/basic.html
+++ b/test/basic.html
@@ -39,19 +39,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <test-fixture id="icon-fab">
     <template>
-        <paper-fab icon="favorite" label="favorite icon"></paper-fab>
+      <paper-fab icon="favorite" label="favorite icon"></paper-fab>
     </template>
   </test-fixture>
 
   <test-fixture id="icon-src-fab">
     <template>
-        <paper-fab src="add.png" label="add icon"></paper-fab>
+      <paper-fab src="add.png" label="add icon"></paper-fab>
     </template>
   </test-fixture>
 
   <test-fixture id="label-fab">
     <template>
-        <paper-fab label="HTML"></paper-fab>
+      <paper-fab label="HTML"></paper-fab>
     </template>
   </test-fixture>
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -96,8 +96,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     
     test('fab displays icon with `icon` and `label` attributes', function(done) {
       Polymer.Base.async(function() {
-        var icon = Polymer.dom(f3.root).querySelector('iron-icon');
-        var text = Polymer.dom(f3.root).querySelector('#fab-text');
+        var icon = f3.$$('iron-icon');
+        var text = f3.$$('span');
         expect(icon).not.to.be.null;
         assert.strictEqual(!!icon.hidden, false);
         assert.strictEqual(!!text.hidden, true);
@@ -109,8 +109,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     
     test('fab displays icon with `src` and `label` attributes', function(done) {
       Polymer.Base.async(function() {
-        var icon = Polymer.dom(f4.root).querySelector('iron-icon');
-        var text = Polymer.dom(f4.root).querySelector('#fab-text');
+        var icon = f4.$$('iron-icon');
+        var text = f4.$$('span');
         expect(icon).not.to.be.null;
         assert.strictEqual(!!icon.hidden, false);
         assert.strictEqual(!!text.hidden, true);
@@ -122,8 +122,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     
     test('fab displays label with `label` attribute correctly', function(done) {
       Polymer.Base.async(function() {
-        var icon = Polymer.dom(f5.root).querySelector('iron-icon');
-        var text = Polymer.dom(f5.root).querySelector('#fab-text');
+        var icon = f5.$$('iron-icon');
+        var text = f5.$$('span');
         expect(text).not.to.be.null;
         assert.strictEqual(!!icon.hidden, true);
         assert.strictEqual(!!text.hidden, false);

--- a/test/basic.html
+++ b/test/basic.html
@@ -37,10 +37,31 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="icon-fab">
+    <template>
+        <paper-fab icon="favorite" label="favorite icon"></paper-fab>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="icon-src-fab">
+    <template>
+        <paper-fab src="add.png" label="add icon"></paper-fab>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="label-fab">
+    <template>
+        <paper-fab label="HTML"></paper-fab>
+    </template>
+  </test-fixture>
+
   <script>
 
     var f1;
     var f2;
+    var f3;
+    var f4;
+    var f5;
 
     function centerOf(element) {
       var rect = element.getBoundingClientRect();
@@ -54,6 +75,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     setup(function() {
       f1 = fixture('TrivialFab').querySelector('#fab1');
       f2 = fixture('SrcFab');
+      f3 = fixture('icon-fab');
+      f4 = fixture('icon-src-fab');
+      f5 = fixture('label-fab');
     });
 
     test('applies an icon specified by the `icon` attribute', function() {
@@ -68,6 +92,45 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     test('renders correctly independent of line height', function() {
       assert.ok(approxEqual(centerOf(f1.$.icon), centerOf(f1)));
+    });
+    
+    test('fab displays icon with `icon` and `label` attributes', function(done) {
+      Polymer.Base.async(function() {
+        var icon = Polymer.dom(f3.root).querySelector('iron-icon');
+        var text = Polymer.dom(f3.root).querySelector('#fab-text');
+        expect(icon).not.to.be.null;
+        assert.strictEqual(!!icon.hidden, false);
+        assert.strictEqual(!!text.hidden, true);
+        expect(icon.icon).to.be.equal(f3.icon);
+        expect(f3.getAttribute('aria-label')).to.be.equal(f3.label);
+        done();
+      });
+    });
+    
+    test('fab displays icon with `src` and `label` attributes', function(done) {
+      Polymer.Base.async(function() {
+        var icon = Polymer.dom(f4.root).querySelector('iron-icon');
+        var text = Polymer.dom(f4.root).querySelector('#fab-text');
+        expect(icon).not.to.be.null;
+        assert.strictEqual(!!icon.hidden, false);
+        assert.strictEqual(!!text.hidden, true);
+        expect(icon.src).to.be.equal(f4.src);
+        expect(f4.getAttribute('aria-label')).to.be.equal(f4.label);
+        done();
+      });
+    });
+    
+    test('fab displays label with `label` attribute correctly', function(done) {
+      Polymer.Base.async(function() {
+        var icon = Polymer.dom(f5.root).querySelector('iron-icon');
+        var text = Polymer.dom(f5.root).querySelector('#fab-text');
+        expect(text).not.to.be.null;
+        assert.strictEqual(!!icon.hidden, true);
+        assert.strictEqual(!!text.hidden, false);
+        expect(text.innerHTML).to.be.equal(f5.label);
+        expect(f5.getAttribute('aria-label')).to.be.equal(f5.label);
+        done();
+      });
     });
   </script>
 </body>


### PR DESCRIPTION
Basically, this is a replication of paper-badge's label support.

Regarding https://github.com/PolymerElements/paper-fab/issues/56#issuecomment-174077746, there are not currently any limits on the number of characters allowed within the label.

I, personally, am going to use this to display 3-letter file extensions in the label.  So I'd prefer a limit of 3 over a limit of 2.  (Or maybe a configurable property representing the ```label-limit```, that would allow the user to specify truncation?)