### PR TITLE
Center label; add example to demo

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -40,8 +40,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <h3>FABs can be enabled or disabled</h3>
     <demo-snippet class="centered-demo">
       <template>
+        <style>
+          paper-fab.label {
+            font-size: 20px;
+          }
+        </style>
         <paper-fab icon="favorite" title="heart"></paper-fab>
         <paper-fab disabled icon="reply" title="reply"></paper-fab>
+        <paper-fab class="label" label="😻" title="heart eyes cat"></paper-fab>
       </template>
     </demo-snippet>
 
@@ -50,6 +56,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <template>
         <paper-fab mini icon="favorite" title="heart"></paper-fab>
         <paper-fab mini disabled icon="reply" title="reply"></paper-fab>
+        <paper-fab mini class="label" label="😻" title="heart eyes cat"></paper-fab>
       </template>
     </demo-snippet>
 

--- a/paper-fab.html
+++ b/paper-fab.html
@@ -85,6 +85,10 @@ Custom property | Description | Default
         @apply(--paper-fab);
       }
 
+      [hidden] {
+        display: none !important;
+      }
+
       :host([mini]) {
         width: 40px;
         height: 40px;
@@ -103,12 +107,13 @@ Custom property | Description | Default
       iron-icon {
         @apply(--paper-fab-iron-icon);
       }
-      
+
       span {
         width: 100%;
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
+        text-align: center;
       }
 
       :host(.keyboard-focus) {
@@ -156,7 +161,7 @@ Custom property | Description | Default
           value: false,
           reflectToAttribute: true
         },
-        
+
         /**
          * The label displayed in the badge. The label is centered, and ideally
          * should have very few characters.
@@ -166,11 +171,11 @@ Custom property | Description | Default
           observer: '_labelChanged'
         }
       },
-      
+
       _labelChanged: function() {
         this.setAttribute('aria-label', this.label);
       },
-      
+
       _computeIsIconFab: function(icon, src) {
         return (icon.length > 0) || (src.length > 0);
       }

--- a/test/a11y.html
+++ b/test/a11y.html
@@ -55,8 +55,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       assert.strictEqual(f2.getAttribute('aria-disabled'), 'false');
     });
 
-    test('aria-label is set');
-
     test('user-defined aria-label is preserved', function() {
       assert.strictEqual(f3.getAttribute('aria-label'), 'custom');
       f3.icon = 'arrow-forward';

--- a/test/basic.html
+++ b/test/basic.html
@@ -56,7 +56,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </test-fixture>
 
   <script>
-
     var f1;
     var f2;
     var f3;
@@ -72,6 +71,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       return Math.round(p1.left) == Math.round(p2.left) && Math.round(p1.top) == Math.round(p2.top);
     }
 
+    function isHidden(element) {
+      var rect = element.getBoundingClientRect();
+      return (rect.width == 0 && rect.height == 0);
+    }
+
     setup(function() {
       f1 = fixture('TrivialFab').querySelector('#fab1');
       f2 = fixture('SrcFab');
@@ -81,52 +85,52 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     });
 
     test('applies an icon specified by the `icon` attribute', function() {
-      assert.strictEqual(!!f1.$.icon.usesSrcAttribute, false);
+      assert.isFalse(!!f1.$.icon.usesSrcAttribute);
       assert.ok(Polymer.dom(f1.$.icon.root).querySelector('svg'));
     });
 
     test('applies an icon specified by the `src` attribute', function() {
-      assert.strictEqual(f2.$.icon._usesIconset(), false);
+      assert.isFalse(f2.$.icon._usesIconset());
       assert.ok(f2.$.icon._img);
     });
 
     test('renders correctly independent of line height', function() {
       assert.ok(approxEqual(centerOf(f1.$.icon), centerOf(f1)));
     });
-    
+
     test('fab displays icon with `icon` and `label` attributes', function(done) {
       Polymer.Base.async(function() {
         var icon = f3.$$('iron-icon');
         var text = f3.$$('span');
         expect(icon).not.to.be.null;
-        assert.strictEqual(!!icon.hidden, false);
-        assert.strictEqual(!!text.hidden, true);
+        assert.isFalse(isHidden(icon));
+        assert.isTrue(isHidden(text));
         expect(icon.icon).to.be.equal(f3.icon);
         expect(f3.getAttribute('aria-label')).to.be.equal(f3.label);
         done();
       });
     });
-    
+
     test('fab displays icon with `src` and `label` attributes', function(done) {
       Polymer.Base.async(function() {
         var icon = f4.$$('iron-icon');
         var text = f4.$$('span');
         expect(icon).not.to.be.null;
-        assert.strictEqual(!!icon.hidden, false);
-        assert.strictEqual(!!text.hidden, true);
+        assert.isFalse(isHidden(icon));
+        assert.isTrue(isHidden(text));
         expect(icon.src).to.be.equal(f4.src);
         expect(f4.getAttribute('aria-label')).to.be.equal(f4.label);
         done();
       });
     });
-    
+
     test('fab displays label with `label` attribute correctly', function(done) {
       Polymer.Base.async(function() {
         var icon = f5.$$('iron-icon');
         var text = f5.$$('span');
         expect(text).not.to.be.null;
-        assert.strictEqual(!!icon.hidden, true);
-        assert.strictEqual(!!text.hidden, false);
+        assert.isTrue(isHidden(icon));
+        assert.isFalse(isHidden(text));
         expect(text.innerHTML).to.be.equal(f5.label);
         expect(f5.getAttribute('aria-label')).to.be.equal(f5.label);
         done();


### PR DESCRIPTION
I just merged https://github.com/PolymerElements/paper-fab/pull/60, but realized the label wasn't centered. Also added an example to the demo and a mixin!

<img width="96" alt="screen shot 2016-02-12 at 11 30 38 am" src="https://cloud.githubusercontent.com/assets/1369170/13017973/1fb009d8-d17c-11e5-8c03-807114734d0d.png">


Also, since the original PR was a community one, it only ran on FF and Chrome -- the tests fail on IE10 because `hidden` is not defined. So I added a style and rejiggered the tests to not look at the attribute. Soon, soon this will end.
