### PR TITLE
Changed dependency from iron-icon to iron-icons

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,6 @@
   "homepage": "https://github.com/PolymerElements/paper-fab",
   "dependencies": {
     "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.0.0",
-    "iron-icon": "PolymerElements/iron-icon#^1.0.0",
     "iron-icons": "PolymerElements/iron-icons#^1.0.0",
     "paper-behaviors": "PolymerElements/paper-behaviors#^1.0.0",
     "paper-material": "PolymerElements/paper-material#^1.0.5",

--- a/paper-fab.html
+++ b/paper-fab.html
@@ -10,7 +10,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
-<link rel="import" href="../iron-icon/iron-icon.html">
+<link rel="import" href="../iron-icons/iron-icons.html">
 <link rel="import" href="../paper-behaviors/paper-button-behavior.html">
 <link rel="import" href="../paper-material/paper-material-shared-styles.html">
 <link rel="import" href="../paper-styles/color.html">

--- a/test/basic.html
+++ b/test/basic.html
@@ -16,8 +16,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <script src="../../web-component-tester/browser.js"></script>
-
-  <link rel="import" href="../../iron-icons/iron-icons.html">
   <link rel="import" href="../paper-fab.html">
 
 </head>


### PR DESCRIPTION
_Changed the dependencies due to three reasons-_

1. **paper-fab** needs iron-icons by default - User should not explicitly import **iron-icons** if it is importing **paper-fab** .
2. If we import **iron-icons** , it will automatically import **iron-icon** 
3. Bower dependency is already there in _bower.json_ file for **iron-icons**

Also I have removed **iron-icon** dependency from _brower.json_ file of **paper-icons** because it is already there in _bower.json_ of **iron-icons** folder.
 